### PR TITLE
Add dna-claude-analysis to Bioinformatics section

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@
 - [Web Scraping](#web-scraping)
 - [Spatial Analysis](#spatial-analysis)
 - [Quantum Computing](#quantum-computing)
+- [Bioinformatics](#bioinformatics)
 - [Conversion](#conversion)
 - [Contributing](#contributing)
 - [License](#license)
@@ -551,6 +552,9 @@
 * [cirq](https://github.com/quantumlib/Cirq) - A python framework for creating, editing, and invoking Noisy Intermediate Scale Quantum (NISQ) circuits.
 * [PennyLane](https://github.com/XanaduAI/pennylane) - Quantum machine learning, automatic differentiation, and optimization of hybrid quantum-classical computations.
 * [QML](https://github.com/qmlcode/qml) - A Python Toolkit for Quantum Machine Learning.
+
+## Bioinformatics
+* [dna-claude-analysis](https://github.com/shmlkv/dna-claude-analysis) - Personal genome analysis toolkit with Python scripts analyzing raw DNA data across 17 categories (health risks, ancestry, pharmacogenomics, nutrition, psychology, etc.) and generating a terminal-style single-page HTML visualization.
 
 ## Conversion
 * [sklearn-porter](https://github.com/nok/sklearn-porter) - Transpile trained scikit-learn estimators to C, Java, JavaScript, and others.


### PR DESCRIPTION
## Description

Adds a new **Bioinformatics** section to the list and includes [dna-claude-analysis](https://github.com/shmlkv/dna-claude-analysis) — a personal genome analysis toolkit written in Python.

### What it does

- Analyzes raw DNA data files across **17 categories**: health risks, ancestry, pharmacogenomics, nutrition, sports/fitness, psychology, cognitive traits, longevity, sleep, immunity, pain sensitivity, detoxification, skin, vision/hearing, physical traits, and carrier status
- Outputs structured markdown reports per category
- Generates a **single-page HTML visualization** with a terminal/hacker aesthetic (no external JS/CSS dependencies)

### Why it belongs here

There is currently no Bioinformatics section in this list. Genomic data analysis is a growing area of Python data science work, and this toolkit demonstrates a practical end-to-end pipeline: raw data ingestion → per-category analysis scripts → report generation → HTML visualization.

## Changes

- Added `- [Bioinformatics](#bioinformatics)` entry in the Contents table of contents
- Added a new `## Bioinformatics` section after Quantum Computing with the `dna-claude-analysis` entry