### PR TITLE
Add Deploybase

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,7 @@
 * [datapane](https://datapane.com/) - A collection of APIs to turn scripts and notebooks into interactive reports.
 * [binder](https://mybinder.org/) - Enable sharing and execute Jupyter Notebooks
 * [Deepnote](https://github.com/deepnote/deepnote) - Deepnote is a drop-in replacement for Jupyter with an AI-first design, sleek UI, new blocks, and native data integrations. Use Python, R, and SQL locally in your favorite IDE, then scale to Deepnote cloud for real-time collaboration, Deepnote agent, and deployable data apps.
+* [Deploybase](https://deploybase.ai/) - Track real-time GPU and LLM pricing across all cloud and inference providers.
 
 
 ## Statistics


### PR DESCRIPTION
Adding Deploybase, a real-time GPU and LLM pricing aggregator dashboard. Helpful for data scientists comparing cloud compute costs when deploying models.