### PR TITLE
Add chunktuner to Natural Language Processing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@
 * [skift](https://github.com/shaypal5/skift) - Scikit-learn wrappers for Python fastText. <img height="20" src="img/sklearn_big.png" alt="sklearn">
 * [Phonemizer](https://github.com/bootphon/phonemizer) - Simple text-to-phonemes converter for multiple languages.
 * [flair](https://github.com/zalandoresearch/flair) - Very simple framework for state-of-the-art NLP.
+* [chunktuner](https://github.com/shantanu-deshmukh/chunktuner) - Library and CLI to benchmark document chunking strategies for retrieval-augmented generation and recommend configurations using retrieval metrics.
 
 ## Computer Audition
 * [torchaudio](https://github.com/pytorch/audio) - An audio library for PyTorch. <img height="20" src="img/pytorch_big2.png" alt="PyTorch based/compatible">


### PR DESCRIPTION
Adds [chunktuner](https://github.com/shantanu-deshmukh/chunktuner) to the **Natural Language Processing** section, appended per project contribution rules.

### Why NLP section

- **Text processing for ML pipelines:** chunking is a core preprocessing decision for embedding-based retrieval; data scientists building RAG need tooling beyond classic tokenizers.
- **Python + PyPI:** consistent with other libraries in this awesome list.
- **Evaluation focus:** complements DS practice of measuring model/pipeline quality rather than guessing chunk sizes.
