### PR TITLE
Add AI Models Catalog to NLP section

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@
 * [Phonemizer](https://github.com/bootphon/phonemizer) - Simple text-to-phonemes converter for multiple languages.
 * [flair](https://github.com/zalandoresearch/flair) - Very simple framework for state-of-the-art NLP.
 
+* [AI Models Catalog](https://github.com/i-need-token/ai-models) - Structured database of 4,587+ AI models across 95 providers with pricing, context windows, and capabilities. Machine-readable YAML with TypeScript types and Zod validation. [Interactive catalog](https://i-need-token.github.io/ai-models/)
 ## Computer Audition
 * [torchaudio](https://github.com/pytorch/audio) - An audio library for PyTorch. <img height="20" src="img/pytorch_big2.png" alt="PyTorch based/compatible">
 * [librosa](https://github.com/librosa/librosa) - Python library for audio and music analysis.


### PR DESCRIPTION
## Description

Adds the AI Models Catalog to the Natural Language Processing section — a structured, open-source database of 4,587+ AI models across 95 providers with pricing, context windows, modalities, and capabilities.

## Why This Is Useful for Python Data Scientists

- **Model comparison**: Compare pricing, context windows, and capabilities across 95 providers
- **Interactive catalog**: https://i-need-token.github.io/ai-models/
- **npm package + JSON/CSV downloads**: Programmatic access to model data
- **First-party data**: All data sourced from provider APIs, not aggregators
- **Machine-readable YAML**: TypeScript types + Zod validation

## Links

- GitHub: https://github.com/i-need-token/ai-models
- Interactive Catalog: https://i-need-token.github.io/ai-models/
- LLM Pricing Comparison: https://i-need-token.github.io/ai-models/llm-pricing.html

## Checklist

- [x] The entry follows the existing format of the list
- [x] The entry is relevant to Python data scientists working with LLMs
- [x] The description is concise and follows the style of other entries