### PR TITLE
Add Wickra to Time Series

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@
 * [dateutil](https://dateutil.readthedocs.io/en/stable/) - Powerful extensions to the standard datetime module
 * [maya](https://github.com/timofurrer/maya) - makes it very easy to parse a string and for changing timezones
 * [Chaos Genius](https://github.com/chaos-genius/chaos_genius) - ML powered analytics engine for outlier/anomaly detection and root cause analysis
+* [Wickra](https://github.com/wickra-lib/wickra) - Technical-analysis indicators for time series: 514 incremental (O(1)/tick) indicators over a Rust core, installable with pip install wickra.
 
 ## Reinforcement Learning
 * [Gymnasium](https://github.com/Farama-Foundation/Gymnasium) - An API standard for single-agent reinforcement learning environments, with popular reference environments and related utilities (formerly [Gym](https://github.com/openai/gym)).


### PR DESCRIPTION
Adds Wickra to the Time Series section.

Wickra is an open-source (MIT OR Apache-2.0) technical-analysis library for time series, with a Rust core and a Python package (pip install wickra - precompiled wheels, no build step, no system dependencies).

Highlights:
- 514 indicators across 24 families, every one computed incrementally in O(1) per data point.
- Identical results in batch (whole-array) and streaming (tick-by-tick) modes - bit-exact, fuzzed and 100%-line-covered for all 514.
- Orders of magnitude faster than recompute-on-every-tick approaches for live/online use.
- Same engine is available from Node.js, WebAssembly, Rust and a C ABI, so a model prototyped in Python deploys unchanged elsewhere.
- MIT OR Apache-2.0.

Repo: https://github.com/wickra-lib/wickra · Docs: https://docs.wickra.org
