### PR TITLE
Add PhilanthroPy

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@
 * [metric-learn](https://github.com/all-umass/metric-learn) - Metric learning algorithms in Python. <img height="20" src="img/sklearn_big.png" alt="sklearn">
 * [pyGAM](https://github.com/dswah/pyGAM) - Generalized Additive Models in Python.
 * [causalml](https://github.com/uber/causalml) - Uplift modeling and causal inference with machine learning algorithms. <img height="20" src="img/sklearn_big.png" alt="sklearn">
+* [PhilanthroPy](https://github.com/PhilanthroPy-Project/PhilanthroPy) - Scikit-learn native toolkit for nonprofit fundraising analytics: donor propensity, lapse, planned-giving, wealth-screening and revenue-forecasting estimators. <img height="20" src="img/sklearn_big.png" alt="sklearn">
 
 ### Gradient Boosting
 * [XGBoost](https://github.com/dmlc/xgboost) - Scalable, Portable, and Distributed Gradient Boosting. <img height="20" src="img/sklearn_big.png" alt="sklearn"> <img height="20" src="img/gpu_big.png" alt="GPU accelerated">


### PR DESCRIPTION
One-line addition under General Purpose Machine Learning: [PhilanthroPy](https://github.com/PhilanthroPy-Project/PhilanthroPy), a scikit-learn native toolkit for nonprofit fundraising analytics (leakage-safe donor propensity, lapse, planned-giving, wealth-screening, revenue-forecasting estimators; passes `check_estimator`).